### PR TITLE
Fix documentation for core lib usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile 'com.hamweather:aeris-android-lib:#.#.#@aar'
+    compile 'com.aerisweather:aeris-core-lib:#.#.#@aar'
 }
 ``` 
 


### PR DESCRIPTION
This caused me quite a bit of trouble, as the only `com.hamweather` archives I found on maven central were for version 1.2.  This updates the README to point to the correct one for archive lib usage in an Android Studio (gradle) project.